### PR TITLE
fix: adapt types to server result

### DIFF
--- a/src/Resource/Sms/SmsMessage.php
+++ b/src/Resource/Sms/SmsMessage.php
@@ -4,14 +4,14 @@ namespace Seven\Api\Resource\Sms;
 
 class SmsMessage {
     protected string $encoding;
-    protected ?string $error = null;
+    protected ?int $error = null;
     protected ?string $errorText = null;
     protected ?int $id = null;
     protected bool $isBinary;
     protected ?string $label;
     protected int $parts;
     protected float $price;
-    protected string $recipient;
+    protected ?string $recipient;
     protected string $sender;
     protected bool $success;
     protected string $text;


### PR DESCRIPTION
If you send a SMS to an invalid receiver (number is "0"), you will receive an response like the one you see in the screenshot.
As you can see "error" is an int (301) and "recipient" is null in the messages array. This will cause an PHP TypeError when the constructor of "SmsMessage" is called.

![Screenshot](https://github.com/user-attachments/assets/bada89d0-a512-4a92-a37f-c83d492f6986)
