### PR TITLE
Fixed return type of getError() function

### DIFF
--- a/src/Resource/Sms/SmsMessage.php
+++ b/src/Resource/Sms/SmsMessage.php
@@ -36,7 +36,7 @@ class SmsMessage {
         return $this->encoding;
     }
 
-    public function getError(): ?string {
+    public function getError(): ?int {
         return $this->error;
     }
 


### PR DESCRIPTION
$error is an integer value in SmsMessage.php